### PR TITLE
Cleanup docs and code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,17 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# -----------------------------------------------------------------------------
+# VSCode
+# -----------------------------------------------------------------------------
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "Dockerfile_*": "dockerfile",
+        "cmath": "cpp"
+    }
+}

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -2,6 +2,7 @@ FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get -y install \
         build-essential \
+        clang-format \
         cmake \
         git \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 **U**LTRA **L**ocates **T**andemly **R**epetitive **A**reas
 
-ULTRA is a tool to find and annotate tandem repeats inside genomic sequence. It is able to find repeats of any length and of any period (up to a maximum period of 4000). It can find highly decayed repeats missed by other software, and it will also be able to find very large repeats in highly repetitive sequence, regardless of the size of sequence or length of repeats. ULTRA offers meaningful annotation scores and can produce annotation P-values at user request.
-
+ULTRA is a tool to find and annotate tandem repeats inside genomic sequence. It
+is able to find repeats of any length and of any period (up to a maximum period
+of 4000). It can find highly decayed repeats missed by other software, and it
+will also be able to find very large repeats in highly repetitive sequence,
+regardless of the size of sequence or length of repeats. ULTRA offers meaningful
+annotation scores and can produce annotation P-values at user request.
 
 ## Install
 
@@ -18,95 +22,138 @@ and run `cmake3` specifically.
 
 ## Run
 
-After building ULTRA you can use it by running “ultra [arguments] <input file> “. ULTRA will produce high quality annotations out of the box, and so we can analyze one of our example files by simply running.
+After building ULTRA you can use it by running:
+
+```
+./ultra [options] <input file>
+```
+
+ULTRA will produce high quality annotations out of the box, and so we can
+analyze one of our example files by simply running.
  
-ultra ./examples/ex1.fa
+```
+ultra examples/ex1.fa
+```
 
 If you want to direct the output to a file you can do so with the -f flag:
 
-ultra -f ./ex1_output.json ./examples/ex1.fa
+```
+ultra -f ex1_output.json examples/ex1.fa
+```
 
-Now there inside your current working directory there will be an ‘ex1_output.json’ file! At the top of this file will be a complete description of the parameters used to run ULTRA, and then there will be a list of repeats found, and their associated annotation information.
-By default, ULTRA has maximum detectable repeat period of 15. Inside examples/ex_large.fa is a period 1000 repeat with a 10% substitution rate. To detect larger period repeats, we will use the -p argument.
+Now your current working directory will contain an `ex1_output.json` file. At
+the top of this file will be a complete description of the parameters used to
+run ULTRA, and then there will be a list of repeats found, and their associated
+annotation information. Output is in JSON format.
 
-ultra -p 1000 -f ./ex_large.json ./examples/ex_large.fa
-
-It’s important to note that ULTRA's runtime grows linearly with maximum period size. It’s also important to note that as a repeat increases in period, it becomes harder to pin down the exact repeat period. Notice how ULTRA labels the period 1000 repeat inside ex_large.fa as being a period 999 repeat with 3 insertions. Period 999 ends up being the most probable explanation of the ex_large.fa repeat given the high substitution rate, even though we have artificially created the repeat and therefor know that it is in fact a period 1000 repeat with no indels.
-
-ULTRA’s default parameters are robust against different levels of AT richness. For example, running ULTRA on ex_at80.fa (random sequence with 80% AT bias and a single tandem repeat in the middle) with default parameters (run: ‘ultra ./examples/ex_at80.fa’) yields a correct repeat annotation with one single tandem repeat found.
-
-However, running ULTRA with default parameters on ex_at90.fa (random sequence with 90% AT bias and a single tandem repeat in the middle) will result in many false positive repeat annotations. We can clean up our annotation by adjusting ULTRA’s expected nucleotide distribution using the -at flag:
-
-ultra -at 0.9 ./examples/ex_at90.fa
-
-Using '-at 0.9', ULTRA will correctly find the only tandem repeat inside the sequence without reporting false positives. 
-
-To see a full list of ULTRA arguments you can use ‘ultra -h’, or see the list of arguments below.
-
-
-
-
+By default, ULTRA has a maximum detectable repeat period of 15. The sequence in
+`examples/ex_large.fa` has a period 1000 repeat with a 10% substitution rate. To
+detect larger period repeats, we will use the -p argument.
 
 ```
-Usage: ultra <arguments> <input sequence path>
+ultra -p 1000 -f ex_large.json examples/ex_large.fa
+```
 
+It's important to note that ULTRA's runtime grows linearly with maximum period
+size. It’s also important to note that as a repeat increases in period, it
+becomes harder to pin down the exact repeat period. 
+
+Notice how ULTRA labels the period 1000 repeat inside `examples/ex_large.fa` as
+being a period 999 repeat with 3 insertions. Period 999 ends up being the most
+probable explanation of the `examples/ex_large.fa` repeat given the high
+substitution rate, even though we have artificially created the repeat and
+therefore know that it is in fact a period 1000 repeat with no indels.
+
+ULTRA's default parameters are robust against different levels of AT richness.
+For example, running ULTRA on ex_at80.fa (random sequence with 80% AT bias and a
+single tandem repeat in the middle) with default parameters (run: `ultra
+examples/ex_at80.fa`) yields a correct repeat annotation with one single tandem
+repeat found.
+
+However, running ULTRA with default parameters on `examples/ex_at90.fa` (random
+sequence with 90% AT bias and a single tandem repeat in the middle) will result
+in many false positive repeat annotations. We can clean up our annotation by
+adjusting ULTRA's expected nucleotide distribution using the `-at` flag:
+
+```
+ultra -at 0.9 examples/ex_at90.fa
+```
+
+Using `-at 0.9`, ULTRA will correctly find the only tandem repeat inside the
+sequence without reporting false positives. 
+
+To see a full list of ULTRA arguments you can use ‘ultra -h’, or see the list of
+arguments below.
+
+```
 ------------------
--flag name  description [default value / behavior]
+0.99.17ultra <arguments> <input sequence path>
 ------------------
--f  Output File Path:                   Path to output csv. [STDOUT]
--s  Score Threshold:                    Minimum score necessary for a repeat to be recorded. [-10000.000000]
--ml Region Length Trheshold:            Minimum total repeat length necessary for a repeat to be recorded. [10]
--mu Repeat Unit Threshold:              Minimum number of repeat units necessary for a repeat to be recorded. [3]
--at AT Richness:                        Frequency of As and Ts in the input sequence. [0.600000]
--atcg ATCG Distribution:                  Frequency of As Ts Cs and Gs in the input sequence. [A=0.300000,T=0.300000,C=0.200000,G=0.200000]
--m  Match Probability:                  Probability of two nucleotides in consecutive repeat units being the same. [0.800000]
+-flag	name	description [default value / behavior]
+------------------
+-f	Output File Path:                   Path to output csv. [STDOUT]
+-s	Score Threshold:                    Minimum score necessary for a repeat to be recorded. [-10000.000000]
+-ml	Region Length Trheshold:            Minimum total repeat length necessary for a repeat to be recorded. [10]
+-mu	Repeat Unit Threshold:              Minimum number of repeat units necessary for a repeat to be recorded. [3]
+-at	AT Richness:                        Frequency of As and Ts in the input sequence. [0.600000]
+-atcg	ATCG Distribution:                  Frequency of As Ts Cs and Gs in the input sequence. [A=0.300000,T=0.300000,C=0.200000,G=0.200000]
+-m	Match Probability:                  Probability of two nucleotides in consecutive repeat units being the same. [0.800000]
 
--n  Number of Threads:                  Number of threads used by ultra to analyze the input sequence. [1]
--p  Maximum Period:                     Largest repeat period detectable by Ultra. [15]
--mi Maximum Consecutive Insertions:     Maximum number of insertions that can occur in tandem. [8]
--md Maximum Consecutive Deletions:      Maximum number of deletions that can occur in tandem. [7]
+-n	Number of Threads:                  Number of threads used by ultra to analyze the input sequence. [1]
+-p	Maximum Period:                     Largest repeat period detectable by Ultra. [15]
+-mi	Maximum Consecutive Insertions:     Maximum number of insertions that can occur in tandem. [8]
+-md	Maximum Consecutive Deletions:      Maximum number of deletions that can occur in tandem. [7]
 
--nr Repeat Probability:                 Probability of transitioning from the nonrepetitive state to a repetitive state. [0.010000]
--rn Repeat Stop Probability:            Probability of transitioning from a repetitive state to the nonrepetitive state. [0.050000]
--pd Repeat probability decay:           **reminder to write a good description later. [0.850000]
--ri Insertion Probability:              Probability of transitioning from a repetitive state to an insertion state. [0.020000]
--rd Deletion Probability:               Probability of transitioning from a repetitive state to a deletion state. [0.020000]
--ii Consecutive Insertion Probability:  The probability of transitioning from an insertion state to another insertion state. [0.020000]
--dd Consecutive Deletion Probability:   The probability of transitioning from a deletion state to another deletion state. [0.020000]
+-nr	Repeat Probability:                 Probability of transitioning from the nonrepetitive state to a repetitive state. [0.010000]
+-rn	Repeat Stop Probability:            Probability of transitioning from a repetitive state to the nonrepetitive state. [0.050000]
+-pd	Repeat probability decay:           **reminder to write a good description later. [0.850000]
+-ri	Insertion Probability:              Probability of transitioning from a repetitive state to an insertion state. [0.020000]
+-rd	Deletion Probability:               Probability of transitioning from a repetitive state to a deletion state. [0.020000]
+-ii	Consecutive Insertion Probability:  The probability of transitioning from an insertion state to another insertion state. [0.020000]
+-dd	Consecutive Deletion Probability:   The probability of transitioning from a deletion state to another deletion state. [0.020000]
 
--sr Split Divergent Repeats:            Split repeats such as ATATATGCGCGCGC into subrepeats. [0]
--sd Split Depth:                        Number of repeat units to consider when splitting repeat. [5]
--sc Split Cutoff:                       Cutoff value used during splitting (smaller is more conservative). [2]
--msp  Split Max Period:                   Maximum repeat period that will be considered for splitting. [6]
+-sr	***NOT FUNCTIONAL, DON'T USE***:    Split repeats such as ATATATGCGCGCGC into subrepeats ATATAT and GCGCGCGC. [0]
+-sd	Split Depth:                        Number of repeat units to consider when splitting repeat. [5]
+-sc	Split Cutoff:                       Cutoff value used during splitting (smaller is more conservative). [2]
+-msp	Split Max Period:                   Maximum repeat period that will be considered for splitting. [6]
 
--hs Hide Repeat Sequence:               Don't show the repetitive sequences in the results CSV. [Show Repeat Sequence]
--ss Show scores:                        Output the score change per residue. [False]
--st Show traceback:                     Output the Viterbi traceback in the results CSV. [Hide traceback]
--wid  Show Window ID:                     Display the windowID corresponding to a repeat in the results CSV. [Hide Window ID]
--json Read JSON file:                     Process all passes in JSON file. [False]
--jpass  Process passes in JSON file:        Process selected passes in JSON file. [None]
--pid  Pass ID:                            Assigns a custom pass ID. [Smallest unused positive pass ID]
--R  Completely Read File:               Read the entire input file during initialization.. [Do not read whole file]
--ws Window Size:                        The number of nucleotides per sequence window. [8192]
--os Window Overlap:                     The number of nucleotides overlaped between two consecutive windows. [100]
--wn Number of Windows:                  Maximum number of windows stored in memory at once. [1024]
--v  Ultra Version:                      Shows Ultra's version. []
+-hs	Hide Repeat Sequence:               Don't show the repetitive sequences in the results CSV. [Show Repeat Sequence]
+-ss	Show score Deltas:                  Output the score change per residue. [False]
+-st	Show traceback:                     Output the Viterbi traceback in the results CSV. [Hide traceback]
+-wid	Show Window ID:                     Display the windowID corresponding to a repeat in the results CSV. [Hide Window ID]
+-sl	Show logo numbers:                  Output the corresponding logo annotation for a given repeat. [Hide logo numbers]
+-json	Read JSON file:                     Process all passes in JSON file. [False]
+-jpass	Process passes in JSON file:        Process selected passes in JSON file. [None]
+-pid	Pass ID:                            Assigns a custom pass ID. [Smallest unused positive pass ID]
+-R	Completely Read File:               Read the entire input file during initialization.. [Do not read whole file]
+-ws	Window Size:                        The number of nucleotides per sequence window. [8192]
+-os	Window Overlap:                     The number of nucleotides overlaped between two consecutive windows. [100]
+-wn	Number of Windows:                  Maximum number of windows stored in memory at once. [1024]
+-v	Ultra Version:                      Shows Ultra's version. []
 
--doc  Debug overlap correction:           Report overlap correction in repeat information. [0]
+-doc	Debug overlap correction:           Report overlap correction in repeat information. [0]
 ```
 
 ## Development
 
 ULTRA is written in C++ 17. Source files can be found in `src/`.
 
-Run `cmake .` to generate the Makefile, then there are a couple custom targets
-beyond what is necessary to build the software.
+Run `cmake .` to generate the Makefile, then the following targets should work:
 
   * `make format` - format the code using clang-format
-  * `make check-format` - verify that formatting is correct
-  * `make container-build` - build the Docker container used in CI
-  * `make container-push` - push the container to Docker Hub
   * `make examples` - run all examples
+
+To run the code formatter (`clang-format`) use `./tool/run-format.sh`.
+
+There are two Docker containers, one for building the software (used in CI) and
+another for running the software (this is the principle means by which we
+distribute ULTRA).
+
+Build and push the builder image: `./tool/build-builder-image.sh` and
+`./tool/push-builder-image.sh`. Build and push the runner image:
+`./tool/build-runner-image.sh` and `./tool/push-runner-image.sh`.
+
+Please make a GitHub pull request to propose changes to the code.
 
 ## License
 

--- a/src/FileReader.cpp
+++ b/src/FileReader.cpp
@@ -2,9 +2,6 @@
 //  FileReader.cpp
 //  ultrax
 //
-//  Created by Daniel Olson on 10/16/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #include "FileReader.hpp"
 

--- a/src/FileReader.hpp
+++ b/src/FileReader.hpp
@@ -2,9 +2,6 @@
 //  FileReader.hpp
 //  ultrax
 //
-//  Created by Daniel Olson on 10/16/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #ifndef FileReader_hpp
 #define FileReader_hpp

--- a/src/JSONPass.cpp
+++ b/src/JSONPass.cpp
@@ -2,9 +2,6 @@
 //  JSONPass.cpp
 //  ultrax
 //
-//  Created by Daniel Olson on 10/2/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #include "JSONPass.hpp"
 

--- a/src/JSONPass.hpp
+++ b/src/JSONPass.hpp
@@ -2,9 +2,6 @@
 //  JSONPass.hpp
 //  ultrax
 //
-//  Created by Daniel Olson on 10/2/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #ifndef JSONPass_hpp
 #define JSONPass_hpp

--- a/src/JSONReader.cpp
+++ b/src/JSONReader.cpp
@@ -2,9 +2,6 @@
 //  JSONReader.cpp
 //  ultrax
 //
-//  Created by Daniel Olson on 10/16/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #include "JSONReader.hpp"
 

--- a/src/JSONReader.hpp
+++ b/src/JSONReader.hpp
@@ -2,9 +2,6 @@
 //  JSONReader.hpp
 //  ultrax
 //
-//  Created by Daniel Olson on 10/16/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #ifndef JSONReader_hpp
 #define JSONReader_hpp

--- a/src/JSONRepeat.cpp
+++ b/src/JSONRepeat.cpp
@@ -2,9 +2,6 @@
 //  JSONRepeat.cpp
 //  ultrax
 //
-//  Created by Daniel Olson on 9/25/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #include "JSONRepeat.hpp"
 

--- a/src/JSONRepeat.hpp
+++ b/src/JSONRepeat.hpp
@@ -2,9 +2,6 @@
 //  JSONRepeat.hpp
 //  ultrax
 //
-//  Created by Daniel Olson on 9/25/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #ifndef JSONRepeat_hpp
 #define JSONRepeat_hpp

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2,9 +2,6 @@
 //  settings.cpp
 //  ultraP
 //
-//  Created by Daniel Olson on 7/3/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #include "settings.hpp"
 
@@ -13,19 +10,14 @@ bool setting_param::operator==(const t_set_param &p) const {
 }
 
 std::string Settings::StringUsage() {
-
-  return "ultra <arguments> <input sequence path>\n";
+  return "usage: ultra [options] <input file>";
 }
 
 std::string Settings::StringVersion() { return ULTRA_VERSION_STRING; }
 
 std::string Settings::StringHelp() {
-  std::string helpString = "------------------\n";
-  helpString += StringVersion();
-  helpString += StringUsage();
-  helpString += "------------------\n";
-  helpString += "-flag\tname\tdescription [default value / behavior]\n";
-  helpString += "------------------\n";
+  std::string helpString = StringUsage();
+  helpString += "\n\navailable options:\n";
 
   long long longestName = 0;
   for (int i = 0; i < settings.size(); ++i) {
@@ -398,7 +390,7 @@ int Settings::InterpretArgument(setting_param arg, int argc, const char **argv,
     }
 
     else if (arg == showVersion) {
-      printf("%s\n", ULTRA_VERSION_STRING);
+      printf("%s\n", StringVersion().c_str());
       exit(0);
     }
 

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -2,9 +2,6 @@
 //  settings.hpp
 //  ultraP
 //
-//  Created by Daniel Olson on 7/3/19.
-//  Copyright © 2019 Daniel Olson. All rights reserved.
-//
 
 #ifndef settings_hpp
 #define settings_hpp
@@ -13,7 +10,7 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-//#include <string.h>
+
 #define ULTRA_VERSION_STRING "0.99.17"
 
 typedef struct t_set_param {
@@ -192,16 +189,16 @@ public:
       "deletion state",
       "dd", 1};
 
-  setting_param outFilePath = {"Output File Path", "Path to output csv", "f",
-                               1};
+  setting_param outFilePath = {"Output File Path", "Path to output JSON data",
+                               "f", 1};
 
   setting_param hideRepeatSequence = {
       "Hide Repeat Sequence",
-      "Don't show the repetitive sequences in the results CSV", "hs", 0};
+      "Don't show the repetitive sequences in the results JSON", "hs", 0};
 
   setting_param showWindowID = {
       "Show Window ID",
-      "Display the windowID corresponding to a repeat in the results CSV",
+      "Display the windowID corresponding to a repeat in the results JSON",
       "wid", 0};
 
   setting_param showScores = {
@@ -211,8 +208,8 @@ public:
   };
 
   setting_param showTraceback = {
-      "Show traceback", "Output the Viterbi traceback in the results CSV", "st",
-      0};
+      "Show traceback", "Output the Viterbi traceback in the results JSON",
+      "st", 0};
 
   setting_param showLogoNumbers = {
       "Show logo numbers",

--- a/src/ultra.cpp
+++ b/src/ultra.cpp
@@ -3,8 +3,9 @@
 //  ultraP
 //
 
-#include "ultra.hpp"
 #include <cmath>
+
+#include "ultra.hpp"
 
 void *UltraThreadLaunch(void *dat) {
   uthread *uth = (uthread *)dat;
@@ -454,7 +455,7 @@ void Ultra::OutputJSONStart() {
 
   fprintf(out, "{");
   fprintf(out, "\"Pass ID\": %i,\n", passID);
-  fprintf(out, "\"Version\": \"%s\",\n", ULTRA_VERSION_STRING);
+  fprintf(out, "\"Version\": \"%s\",\n", settings->StringVersion().c_str());
   fprintf(out, "\"Parameters\": {\n");
   fprintf(out, "%s\n}\n}],\n", settings->JSONString().c_str());
 

--- a/src/ultra.hpp
+++ b/src/ultra.hpp
@@ -6,21 +6,18 @@
 #ifndef ultra_hpp
 #define ultra_hpp
 
+#include <algorithm>
+#include <pthread.h>
 #include <stdio.h>
 #include <vector>
 
 #include "FASTAReader.hpp"
 #include "FileReader.hpp"
 #include "JSONReader.hpp"
+#include "repeat.hpp"
+#include "settings.hpp"
 #include "umatrix.hpp"
 #include "umodel.hpp"
-
-#include "repeat.hpp"
-#include <algorithm>
-#include <stdio.h>
-//#include <omp.h>
-#include "settings.hpp"
-#include <pthread.h>
 
 class Ultra;
 
@@ -37,7 +34,6 @@ public:
   Settings *settings = NULL;
 
   FileReader *reader = NULL;
-  // FASTAReader*    reader  = NULL;
 
   int numberOfThreads = 1;
   int minReaderSize = 100;
@@ -51,7 +47,6 @@ public:
   bool outputReadID = false;
   bool multithreading = false;
   bool AnalyzingJSON = false;
-  // bool outputSequenceSummary  = true;
 
   bool canOutput = false;
   bool firstRepeat = true;


### PR DESCRIPTION
This fixes some oversights in the docs and `-h` content, mostly. It also removes superfluous copyright notices and dead code.