### PR TITLE
Move <vector> import to repeat header

### DIFF
--- a/src/repeat.cpp
+++ b/src/repeat.cpp
@@ -4,7 +4,6 @@
 //
 
 #include "repeat.hpp"
-#include <vector>
 
 void RepeatRegion::CreateLogo(SequenceWindow *window, UMatrix *matrix) {
   logoMemory = (int *)malloc(sizeof(int) * repeatPeriod * (NUM_SYMBOLS + 1));

--- a/src/repeat.hpp
+++ b/src/repeat.hpp
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <string>
+#include <vector>
 
 #include "SequenceWindow.hpp"
 #include "Symbol.hpp"


### PR DESCRIPTION
Move the vector import from the repeat main file to the header to prevent the following error when compiling
```
 error: ‘vector’ in namespace ‘std’ does not name a template type
```
