### PR TITLE
Beta 11 tune

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(
 
 
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+    message(STATUS "Setting CMAKE_BUILD_TYPE=Release")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,13 @@ project(
         HOMEPAGE_URL https://github.com/TravisWheelerLab/ULTRA
 )
 
+
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(
         LIB_CPP_FILES
 

--- a/src/FASTAReader.cpp
+++ b/src/FASTAReader.cpp
@@ -62,7 +62,7 @@ bool FASTAReader::FillWindows() {
         win = GetWaitingWindow();
       }
 
-      if (ReadWindow(win) == false) {
+      if (!ReadWindow(win)) {
         return false;
       }
 
@@ -132,7 +132,7 @@ bool FASTAReader::ReadWindow(SequenceWindow *window) {
   while (true) {
 
     if (linePlace >= 0 && linePlace < READ_ALL) {
-      linePlace = window->ReadLine(line, linePlace);
+      linePlace = window->ReadLine(line, linePlace, total_seq_length);
 
       // Check to see if we can't read anything else into the window
       if (linePlace >= 0 && linePlace < READ_ALL) {
@@ -265,6 +265,8 @@ FASTAReader::FASTAReader(std::string filePath, int mxWindows,
                          unsigned long mxSeqLength,
                          unsigned long mxOverlapLength) {
 
+  total_seq_length = 0;
+
   overlapLength = 0;
   sequenceName = "";
   sequenceID = 0;
@@ -338,6 +340,8 @@ FASTAReader::FASTAReader(unsigned long rn, int maxWindows,
   doneReadingFile = false;
   symbolsReadInSeq = 0;
 
+  total_seq_length = 0;
+
   readID = 0;
 
   A_pctg = 0.3;
@@ -398,4 +402,7 @@ FASTAReader::~FASTAReader() {
   for (int i = 0; i < maxWindows; ++i) {
     delete windows[i];
   }
+  windows.clear();
+  readyWindows.clear();
+  waitingWindows.clear();
 }

--- a/src/FASTAReader.hpp
+++ b/src/FASTAReader.hpp
@@ -26,6 +26,7 @@ public:
 
   std::string line;
   long long linePlace;
+  unsigned long long total_seq_length;
 
   // change to queues
   std::vector<SequenceWindow *> windows;

--- a/src/FileReader.cpp
+++ b/src/FileReader.cpp
@@ -31,6 +31,14 @@ FileReader::FileReader(std::string JSONFilePath, unsigned long mSeqLength,
   exit(-1);
 }
 
+FileReader::~FileReader() {
+  if (fastaReader) {
+    delete fastaReader;
+    fastaReader = nullptr;
+  }
+
+}
+
 SequenceWindow *FileReader::GetReadyWindow() {
   if (format == FASTA)
     return fastaReader->GetReadyWindow();

--- a/src/FileReader.hpp
+++ b/src/FileReader.hpp
@@ -17,6 +17,7 @@ public:
   unsigned long maxSeqLength;
   unsigned long maxOverlapLength;
 
+
   bool multithread = true;
   file_type format = UNKNOWN;
 
@@ -43,6 +44,7 @@ public:
 
   FileReader(std::string JSONFilePath, unsigned long maxSeqLength,
              unsigned long maxOverlapLength, bool multithread);
+  ~FileReader();
 };
 
 #endif /* FileReader_hpp */

--- a/src/SequenceWindow.cpp
+++ b/src/SequenceWindow.cpp
@@ -4,7 +4,7 @@
 //
 
 #include "SequenceWindow.hpp"
-
+#include <random>
 /*
 bool compareSequenceWindows(SequenceWindow *lhs,
                             SequenceWindow *rhs)
@@ -32,7 +32,7 @@ void SequenceWindow::PrepareWindow(std::string seqName, unsigned long sid,
   }
 }
 
-long long SequenceWindow::ReadLine(std::string line, long long place) {
+long long SequenceWindow::ReadLine(std::string line, long long place, unsigned long long &total_seq_length) {
   // printf ("(mem: %llx overlap:%llx newseq: %llx, length: %llu, place %llu)
   // Reading line: %s\n", (unsigned long)seqMem, (unsigned long)overlapSeq,
   // (unsigned long)newSeq, length, place,  line.c_str());
@@ -57,6 +57,7 @@ long long SequenceWindow::ReadLine(std::string line, long long place) {
       symbol s = SymbolForChar(c);
       newSeq[length++] = s;
       symbolCounts[s] += 1;
+      total_seq_length += 1;
     }
   }
 
@@ -154,4 +155,15 @@ bool CompareSequenceWindows::operator()(SequenceWindow *lhs,
                                         SequenceWindow *rhs) {
   // printf("comparing %lli vs %lli\n", lhs->readID, rhs->readID);
   return lhs->readID > rhs->readID;
+}
+
+void ShuffleSequenceWindow(SequenceWindow *window) {
+  std::random_device rd;  // a seed source for the random number engine
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<unsigned long long> dist;
+  for (unsigned long long i = 0; i < window->length; ++i) {
+    unsigned long long j = dist(gen);
+    j = (j % (window->length - i)) + i;
+    std::swap(window->seq[i], window->seq[j]);
+  }
 }

--- a/src/SequenceWindow.hpp
+++ b/src/SequenceWindow.hpp
@@ -31,7 +31,7 @@ public:
   symbol *seq;    // The beginning of the entire sequence
 
   unsigned long length;  // How many nucleotides are in this window
-  unsigned long overlap; // The length of sequence shared with this.seqID - 1
+  unsigned long overlap; // The length of sequence shared with (this->seqID - 1)
 
   unsigned long symbolCounts[27];
   double symbolFreqs[27];
@@ -44,7 +44,7 @@ public:
 
   // ReadLine() returns how much of line was read
   // and will returns -1 if the line is a new sequence
-  long long ReadLine(std::string line, long long place);
+  long long ReadLine(std::string line, long long place, unsigned long long &total_seq_length);
   void CopyOverlap(symbol *b);
   void CalculateSymbolFrequencies();
 
@@ -58,5 +58,7 @@ class CompareSequenceWindows {
 public:
   bool operator()(SequenceWindow *lhs, SequenceWindow *rhs);
 };
+
+void ShuffleSequenceWindow(SequenceWindow *window);
 
 #endif /* SequenceWindow_hpp */

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -5,7 +5,7 @@
 #ifndef ULTRA_CLI_HPP
 #define ULTRA_CLI_HPP
 
-#define ULTRA_VERSION_STRING "1.0.0 (beta 10)"
+#define ULTRA_VERSION_STRING "1.0.0 (beta 11)"
 
 #include "../lib/CLI11.hpp"
 #include <string>
@@ -63,7 +63,7 @@ struct Settings {
   float c_freq = 0.2;
   float g_freq = 0.2;
   float t_freq = 0.3;
-  std::vector<int> acgt;
+  std::vector<float> acgt;
   float at = 0.6;
   float match_probability = 0.8;
 

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -59,17 +59,17 @@ struct Settings {
   unsigned long long max_delete = 10;
 
   // Probability parameters
-  float a_freq = 0.3;
-  float c_freq = 0.2;
-  float g_freq = 0.2;
-  float t_freq = 0.3;
+  float a_freq = 0.25;
+  float c_freq = 0.25;
+  float g_freq = 0.25;
+  float t_freq = 0.25;
   std::vector<float> acgt;
-  float at = 0.6;
-  float match_probability = 0.8;
+  float at = 0.5;
+  float match_probability = 0.7;
 
   float period_decay = 0.85;
-  float transition_nr = 0.001;
-  float transition_rn = 0.005;
+  float transition_nr = 0.01;
+  float transition_rn = 0.05;
   float transition_ri = 0.02;
   float transition_rd = 0.02;
   float transition_ii = 0.02;

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -53,6 +53,15 @@ struct Settings {
   unsigned long long min_length = 10;
   unsigned long long min_units = 2;
 
+  // Tuning parameters
+
+  double tune_fdr = 0.1;
+  bool tune = false;
+  bool tune_small = false;
+  bool tune_large = false;
+  bool tune_only = false;
+  std::string tune_param_path;
+
   // Model parameters
   unsigned long long max_period = 100;
   unsigned long long max_insert = 10;
@@ -100,5 +109,11 @@ struct Settings {
   void print_memory_usage();
   std::string json_string();
 };
+
+
+std::vector<std::tuple<std::string,Settings *>> default_tune_settings(int argc, const char **argv);
+std::vector<std::tuple<std::string,Settings *>> large_tune_settings(int argc, const char **argv);
+std::vector<std::tuple<std::string,Settings *>> small_tune_settings(int argc, const char **argv);
+std::vector<std::tuple<std::string,Settings *>> tune_settings_for_path(std::string path);
 
 #endif // ULTRA_CLI_HPP

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -57,9 +57,10 @@ struct Settings {
 
   double tune_fdr = 0.1;
   bool tune = false;
-  bool tune_small = false;
+  bool tune_medium = false;
   bool tune_large = false;
   bool tune_only = false;
+  bool tune_indels = false;
   std::string tune_param_path;
 
   // Model parameters
@@ -103,7 +104,9 @@ struct Settings {
                "=================================================\n"};
 
   void prepare_settings();
+  void set_multi_option();
   bool parse_input(int argc, const char **argv);
+  bool parse_multi_input(int argc, const char **argv, std::string arg_str);
   int calculate_num_states();
   void assign_settings();
   void print_memory_usage();
@@ -111,9 +114,12 @@ struct Settings {
 };
 
 
-std::vector<std::tuple<std::string,Settings *>> default_tune_settings(int argc, const char **argv);
-std::vector<std::tuple<std::string,Settings *>> large_tune_settings(int argc, const char **argv);
-std::vector<std::tuple<std::string,Settings *>> small_tune_settings(int argc, const char **argv);
-std::vector<std::tuple<std::string,Settings *>> tune_settings_for_path(std::string path);
+std::vector<std::string> small_tune_settings();
+std::vector<std::string> medium_tune_settings();
+std::vector<std::string> large_tune_settings();
+std::vector<std::string> tune_settings_for_path(std::string path);
+
+void string_to_args(const std::string& str, int& argc, char**& argv);
+std::tuple<int, char**> combine_args(int argc1, const char** argv1, int argc2, char** argv2);
 
 #endif // ULTRA_CLI_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 
 int main(int argc, const char *argv[]) {
 
+  // Prepare settings
   Settings settings;
   settings.prepare_settings();
   if (!settings.parse_input(argc, argv)) {
@@ -17,19 +18,110 @@ int main(int argc, const char *argv[]) {
     exit(0);
   }
 
-  auto *ultra = new Ultra(&settings, 0);
+  // Tuning stuff.
+  std::vector<unsigned long long> coverage;
+  std::vector<unsigned long long> shuffled_coverage;
+  std::vector<std::string> param_strings;
+  std::vector<std::tuple<std::string,Settings *>> search_params;
+  unsigned long long seq_length = 0;
+  if (settings.tune) {
+
+    // Get the parameters we are going to run with
+    if (settings.tune_param_path.empty()) {
+      if (settings.tune_small)
+        search_params = small_tune_settings(argc, argv);
+      else if (settings.tune_large)
+        search_params = large_tune_settings(argc, argv);
+      else
+        search_params = default_tune_settings(argc, argv);
+    }else {
+      search_params = tune_settings_for_path(settings.tune_param_path);
+    }
+
+    // Run ULTRA on each parameter set
+    printf("Performing parameter search...\n");
+    printf("Coverage, False Discovery Rate, Parameters\n");
+
+    int best_coverage_index = -1;
+    double best_coverage = 0.0;
+    for (auto [params, setting] : search_params) {
+      unsigned long cvg_tmp;
+      double real_coverage = 0;
+      double false_coverage = 0;
+
+      // Push back our params
+      param_strings.push_back(params);
+
+      // We first get the normal coverage
+      auto *ultra = new Ultra(setting);
+      ultra->AnalyzeFile();
+      ultra->OutputRepeats(true);
+      seq_length = ultra->reader->fastaReader->total_seq_length;
+      cvg_tmp = ultra->Coverage();
+      real_coverage = (double)cvg_tmp / (double)seq_length;
+      coverage.push_back(cvg_tmp);
+      delete ultra;
+
+      // Next we get our shuffled coverage
+      ultra = new Ultra(setting);
+      ultra->shuffleSequence = true;
+      ultra->AnalyzeFile();
+      ultra->OutputRepeats(true);
+      cvg_tmp = ultra->Coverage();
+      false_coverage = (double)cvg_tmp / (double)seq_length;
+      shuffled_coverage.push_back(cvg_tmp);
+      delete ultra;
+
+      double fdr = 1.0;
+      if (real_coverage > 0.0) {
+        fdr = false_coverage / real_coverage;
+      }
+
+      if (fdr <= settings.tune_fdr) {
+        if (real_coverage > best_coverage) {
+          best_coverage = real_coverage;
+          best_coverage_index = param_strings.size() - 1;
+        }
+      }
+
+      printf("(%zu/%zu): %g, %g, %s\n",(param_strings.size()),
+             search_params.size(),
+             real_coverage, fdr, params.c_str());
+    }
+
+    printf("-----------\n");
+    if (best_coverage_index >= 0) {
+      double real_coverage = (double)coverage[best_coverage_index] / (double)seq_length;
+      double false_coverage = (double)shuffled_coverage[best_coverage_index] / (double)seq_length;
+      double fdr = false_coverage / real_coverage;
+
+      printf("Best coverage within FDR limit: %g, %g, %s\n", real_coverage,
+             fdr,
+             param_strings[best_coverage_index].c_str());
+    } else {
+      printf("No parameters found within FDR limit.\n");
+      exit(0);
+    }
+
+    if (settings.tune_only) {
+      exit(0);
+    }
+  }
+
+  // Perform the actual run
+  auto *ultra = new Ultra(&settings);
   ultra->AnalyzeFile();
   ultra->OutputRepeats(true);
 
-  if (!settings.out_file.empty()) {
-    fclose(ultra->out);
-  }
-
+  // Check to see if we are making a masked file
   if (settings.produce_mask) {
     FILE *f = fopen(settings.mask_file.c_str(), "w");
     OutputMaskedFASTA(settings.in_file, f, ultra->masks_for_seq,
                       settings.mask_with_n);
     fclose(f);
   }
+
+  delete ultra;
+
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,8 @@ int main(int argc, const char *argv[]) {
       search_setting.suppress_out = true;
       search_setting.hide_settings = true;
       search_setting.produce_mask = true;
+      search_setting.no_split = true;
+      search_setting.max_split = 0;
 
       // We first get the normal coverage
       auto *ultra = new Ultra(&search_setting);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,15 +6,15 @@
 int main(int argc, const char *argv[]) {
 
   // Prepare settings
-  Settings settings;
-  settings.prepare_settings();
-  if (!settings.parse_input(argc, argv)) {
+  Settings *settings = new Settings();
+  settings->prepare_settings();
+  if (!settings->parse_input(argc, argv)) {
     exit(0);
   }
 
-  settings.assign_settings();
-  if (settings.show_memory) {
-    settings.print_memory_usage();
+  settings->assign_settings();
+  if (settings->show_memory) {
+    settings->print_memory_usage();
     exit(0);
   }
 
@@ -22,20 +22,19 @@ int main(int argc, const char *argv[]) {
   std::vector<unsigned long long> coverage;
   std::vector<unsigned long long> shuffled_coverage;
   std::vector<std::string> param_strings;
-  std::vector<std::tuple<std::string,Settings *>> search_params;
   unsigned long long seq_length = 0;
-  if (settings.tune) {
+  if (settings->tune) {
 
     // Get the parameters we are going to run with
-    if (settings.tune_param_path.empty()) {
-      if (settings.tune_small)
-        search_params = small_tune_settings(argc, argv);
-      else if (settings.tune_large)
-        search_params = large_tune_settings(argc, argv);
+    if (settings->tune_param_path.empty()) {
+      if (settings->tune_medium)
+        param_strings = medium_tune_settings();
+      else if (settings->tune_large)
+        param_strings = large_tune_settings();
       else
-        search_params = default_tune_settings(argc, argv);
+        param_strings = small_tune_settings();
     }else {
-      search_params = tune_settings_for_path(settings.tune_param_path);
+      param_strings = tune_settings_for_path(settings->tune_param_path);
     }
 
     // Run ULTRA on each parameter set
@@ -44,16 +43,29 @@ int main(int argc, const char *argv[]) {
 
     int best_coverage_index = -1;
     double best_coverage = 0.0;
-    for (auto [params, setting] : search_params) {
+    for (auto arg_string : param_strings) {
       unsigned long cvg_tmp;
       double real_coverage = 0;
       double false_coverage = 0;
 
-      // Push back our params
-      param_strings.push_back(params);
+      Settings search_setting;
+      search_setting.prepare_settings();
+      search_setting.set_multi_option();
+      if (!search_setting.parse_multi_input(argc, argv, arg_string)) {
+        exit(0);
+      }
+      search_setting.assign_settings();
+
+      if (!search_setting.tune_indels) {
+        search_setting.max_insert = 0;
+        search_setting.max_delete = 0;
+      }
+      search_setting.suppress_out = true;
+      search_setting.hide_settings = true;
+      search_setting.produce_mask = true;
 
       // We first get the normal coverage
-      auto *ultra = new Ultra(setting);
+      auto *ultra = new Ultra(&search_setting);
       ultra->AnalyzeFile();
       ultra->OutputRepeats(true);
       seq_length = ultra->reader->fastaReader->total_seq_length;
@@ -63,7 +75,7 @@ int main(int argc, const char *argv[]) {
       delete ultra;
 
       // Next we get our shuffled coverage
-      ultra = new Ultra(setting);
+      ultra = new Ultra(&search_setting);
       ultra->shuffleSequence = true;
       ultra->AnalyzeFile();
       ultra->OutputRepeats(true);
@@ -77,16 +89,16 @@ int main(int argc, const char *argv[]) {
         fdr = false_coverage / real_coverage;
       }
 
-      if (fdr <= settings.tune_fdr) {
+      if (fdr <= settings->tune_fdr) {
         if (real_coverage > best_coverage) {
           best_coverage = real_coverage;
-          best_coverage_index = param_strings.size() - 1;
+          best_coverage_index = coverage.size() - 1;
         }
       }
 
-      printf("(%zu/%zu): %g, %g, %s\n",(param_strings.size()),
-             search_params.size(),
-             real_coverage, fdr, params.c_str());
+      printf("(%zu/%zu): %g, %g, %s\n",(coverage.size()),
+             param_strings.size(),
+             real_coverage, fdr, arg_string.c_str());
     }
 
     printf("-----------\n");
@@ -98,26 +110,35 @@ int main(int argc, const char *argv[]) {
       printf("Best coverage within FDR limit: %g, %g, %s\n", real_coverage,
              fdr,
              param_strings[best_coverage_index].c_str());
+
+      delete settings;
+      settings = new Settings();
+      settings->prepare_settings();
+      settings->set_multi_option();
+      if (!settings->parse_multi_input(argc, argv, param_strings[best_coverage_index])) {
+        exit(0);
+      }
+      settings->assign_settings();
     } else {
       printf("No parameters found within FDR limit.\n");
       exit(0);
     }
 
-    if (settings.tune_only) {
+    if (settings->tune_only) {
       exit(0);
     }
   }
 
   // Perform the actual run
-  auto *ultra = new Ultra(&settings);
+  auto *ultra = new Ultra(settings);
   ultra->AnalyzeFile();
   ultra->OutputRepeats(true);
 
   // Check to see if we are making a masked file
-  if (settings.produce_mask) {
-    FILE *f = fopen(settings.mask_file.c_str(), "w");
-    OutputMaskedFASTA(settings.in_file, f, ultra->masks_for_seq,
-                      settings.mask_with_n);
+  if (settings->produce_mask) {
+    FILE *f = fopen(settings->mask_file.c_str(), "w");
+    OutputMaskedFASTA(settings->in_file, f, ultra->masks_for_seq,
+                      settings->mask_with_n);
     fclose(f);
   }
 

--- a/src/repeat.cpp
+++ b/src/repeat.cpp
@@ -231,6 +231,11 @@ RepeatRegion::~RepeatRegion() {
     logoMemory = nullptr;
   }
 
+  if (logoNumbers != nullptr) {
+    free(logoNumbers);
+    logoNumbers = nullptr;
+  }
+
   if (lookBack != nullptr) {
     free(lookBack);
     lookBack = nullptr;

--- a/src/ultra.hpp
+++ b/src/ultra.hpp
@@ -55,7 +55,7 @@ public:
   bool outputRepeatSequence = true;
   bool outputReadID = false;
   bool multithreading = false;
-  bool AnalyzingJSON = false;
+  bool shuffleSequence = false;
 
   bool storeSequence = false;
   bool storeTraceback = false;
@@ -67,6 +67,7 @@ public:
   unsigned long repeatBuffer = 2000;
 
   bool storeTraceAndSequence = false;
+
 
   std::unordered_map<unsigned long long, std::vector<mregion> *>
       masks_for_seq{};
@@ -98,12 +99,14 @@ public:
   int SmallestReadID();
 
   void SortRepeatRegions();
-  void OutputMaskedFASTA(std::string in_file_path, FILE *out_file);
+  unsigned long long Coverage();
+
   pthread_mutex_t outerLock;
   pthread_mutex_t innerLock;
   pthread_mutex_t repeatLock;
 
-  Ultra(Settings *settings, int numberOfThreads);
+  Ultra(Settings *settings);
+  ~Ultra();
 };
 
 class CompareRepeatOrder {

--- a/src/umodel.cpp
+++ b/src/umodel.cpp
@@ -514,7 +514,6 @@ void UModel::CalculateCurrentColumn(SequenceWindow *sequence, int nucIndex,
 
 /*** UMODEL CLASS MANAGEMENT ***/
 
-UModel::UModel(UMatrix *m) { this->matrix = m; }
 
 UModel::UModel(int maxPeriod, int maxInsertions, int maxDeletions,
                int matrixLength) {
@@ -525,4 +524,9 @@ UModel::UModel(int maxPeriod, int maxInsertions, int maxDeletions,
   // Initialize score distributions here
 }
 
-UModel::~UModel() {}
+UModel::~UModel() {
+  if (matrix) {
+    delete matrix;
+    matrix = nullptr;
+  }
+}

--- a/src/umodel.hpp
+++ b/src/umodel.hpp
@@ -68,9 +68,6 @@ public:
                               bool *canBeRepetitive = NULL);
 
   // Clas management
-
-  UModel(UMatrix *matrix);
-
   UModel(int maxPeriod, int maxInsertions, int maxDeletions, int matrixLength);
 
   ~UModel();


### PR DESCRIPTION
Added some flags/arguments to automatically tune ULTRA parameters around an input sequence. Tuning tries to maximize coverage while minimizing false discovery rate (estimated by shuffling sequence in windows). Flags/options are:=
--tune (tunes against 18 parameter sets)
--tune_medium (tunes against 40 parameter sets
--tune_large (tunes against 252 parameter sets)
--tune_file (tunes against a user defined parameter set. Every line in the file should be arguments to run against)
--tune_only (do not run ULTRA after tuning)
--tune_indels (enables indels while tuning. By default indels are disabled).


- Fixed some memory leaks. There should be less memory consumption when using ULTRA on large files with many repeats. (there should, in fact, be a near constant amount of memory consumption).